### PR TITLE
Update to Godot 4.3 stable

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -62,14 +62,32 @@ States can be selected with pseudo selectors like `Button:disabled` where `disab
 Right now only simplified syntax works with this selector.
 If you use the base syntax like `--colors-font-color`, it will only apply to the normal state.
 
-- `color` -> `font_color`
-- `gap` -> `separation`
-- `padding` -> `content_margin_*`
-- `background` -> `bg_color`
-- `border-width` -> `border_width_*`
-- `border-radius` -> `corner_radius_*`
-- `border-color` -> `border_color`
-- `font-family` -> `font`
+| CSS Property       | Godot Attribute    | Parameters/Type |
+|--------------------|--------------------|------------|
+| anti-aliasing      | anti_aliasing      | bool |
+| anti-aliasing-size | anti_aliasing_size | float |
+| background         | bg_color           | Color |
+| border-blend       | border_blend       | bool |
+| border-color       | border_color       | Color |
+| border-radius      | corner_radius_*    | ints: `<top-left> <top-right> <bottom-right> <bottom-left>` |
+| border-width       | border_width_*     | floats: `<top> <right> <bottom> <left>` |StyleBoxFlat
+| color              | font_color         | Color |
+| corner-detail      | corner_detail      | int |
+| draw-center        | draw_center        | bool |
+| expand-margin      | expand_margin      | floats: `<top> <right> <bottom> <left>` |StyleBoxFlat
+| font-family        | font               | url: `url(res://path/to/font.ttf)` |
+| gap                | separation         | int |
+| padding            | content_margin_*   | floats: `<top> <right> <bottom> <left>` |
+| shadow-color       | shadow_color       | Color |
+| shadow-offset      | shadow_offset      | `<x> <y>` |
+| shadow-size        | shadow_size        | int |
+| skew               | skew               | `<x> <y>` |
+
+See
+[StyleBox](https://docs.godotengine.org/en/stable/classes/class_stylebox.html),
+[StyleBoxFlat](https://docs.godotengine.org/en/stable/classes/class_styleboxflat.html),
+and [BoxContainer](https://docs.godotengine.org/en/stable/classes/class_boxcontainer.html),
+for further reference on Godot attribute names.
 
 ## SCSS
 

--- a/addons/godot-css-theme/CSSSimplifier.gd
+++ b/addons/godot-css-theme/CSSSimplifier.gd
@@ -25,7 +25,7 @@ func simplify(stylesheet: Stylesheet) -> Stylesheet:
 					var mapped_prop = (
 						"--colors-font-color"
 						if state == Stylesheet.DEFAULT_STATE
-						else "--colors-font-color-%s" % state
+						else "--colors-font-%s-color" % state
 					)
 					new_props[mapped_prop] = props["color"]
 

--- a/addons/godot-css-theme/CSSSimplifier.gd
+++ b/addons/godot-css-theme/CSSSimplifier.gd
@@ -34,11 +34,11 @@ func simplify(stylesheet: Stylesheet) -> Stylesheet:
 
 				if props.has("font-family"):
 					var value = props["font-family"]
-					new_props['--fonts-font'] = value
+					new_props["--fonts-font"] = value
 
 				if props.has("font-size"):
-					new_props['--fonts-font-size'] = props["font-size"]
-					
+					new_props["--fonts-font-size"] = props["font-size"]
+
 				if props.has("background"):
 					var value = props["background"]
 					var is_none = value == "none"

--- a/addons/godot-css-theme/CSSSimplifier.gd
+++ b/addons/godot-css-theme/CSSSimplifier.gd
@@ -47,6 +47,18 @@ func simplify(stylesheet: Stylesheet) -> Stylesheet:
 					var color = "Color(0, 0, 0, 0)" if is_none else value
 					new_props[style_prefix + "bg-color"] = color
 
+				if props.has("draw-center"):
+					new_props[style_type] = "Flat"
+					new_props[style_prefix + "draw-center"] = props["draw-center"]
+
+				if props.has("skew"):
+					new_props[style_type] = "Flat"
+					new_props[style_prefix + "skew"] = props["skew"]
+
+				if props.has("corner-detail"):
+					new_props[style_type] = "Flat"
+					new_props[style_prefix + "corner-detail"] = props["corner-detail"]
+
 				if props.has("border-width"):
 					new_props[style_type] = "Flat"
 					_shorthand_sides(
@@ -66,12 +78,43 @@ func simplify(stylesheet: Stylesheet) -> Stylesheet:
 					new_props[style_type] = "Flat"
 					new_props[style_prefix + "border-color"] = props["border-color"]
 
+				if props.has("border-blend"):
+					new_props[style_type] = "Flat"
+					new_props[style_prefix + "border-blend"] = props["border-blend"]
+
 				if props.has("padding"):
 					if not new_props.has(style_type):
 						new_props[style_type] = "Empty"
 
 					_shorthand_sides(new_props, props["padding"], style_prefix + "content-margin")
 
+				if props.has("expand-margin"):
+					new_props[style_type] = "Flat"
+					_shorthand_sides(
+						new_props,
+						props["expand-margin"],
+						style_prefix + "expand-margin",
+					)
+
+				if props.has("shadow-color"):
+					new_props[style_type] = "Flat"
+					new_props[style_prefix + "shadow-color"] = props["shadow-color"]
+
+				if props.has("shadow-size"):
+					new_props[style_type] = "Flat"
+					new_props[style_prefix + "shadow-size"] = props["shadow-size"]
+
+				if props.has("shadow-offset"):
+					new_props[style_type] = "Flat"
+					new_props[style_prefix + "shadow-offset"] = props["shadow-offset"]
+
+				if props.has("anti-aliasing"):
+					new_props[style_type] = "Flat"
+					new_props[style_prefix + "anti-aliasing"] = props["anti-aliasing"]
+
+				if props.has("anti-aliasing-size"):
+					new_props[style_type] = "Flat"
+					new_props[style_prefix + "anti-aliasing-size"] = props["anti-aliasing-size"]
 
 			values[class_group][cls][Stylesheet.DEFAULT_STATE] = new_props
 

--- a/addons/godot-css-theme/CSSSimplifier.gd
+++ b/addons/godot-css-theme/CSSSimplifier.gd
@@ -53,7 +53,11 @@ func simplify(stylesheet: Stylesheet) -> Stylesheet:
 
 				if props.has("skew"):
 					new_props[style_type] = "Flat"
-					new_props[style_prefix + "skew"] = props["skew"]
+					_vector2(
+						new_props,
+						props["skew"],
+						style_prefix + "skew"
+					)
 
 				if props.has("corner-detail"):
 					new_props[style_type] = "Flat"
@@ -106,7 +110,11 @@ func simplify(stylesheet: Stylesheet) -> Stylesheet:
 
 				if props.has("shadow-offset"):
 					new_props[style_type] = "Flat"
-					new_props[style_prefix + "shadow-offset"] = props["shadow-offset"]
+					_vector2(
+						new_props,
+						props["shadow-offset"],
+						style_prefix + "shadow-offset"
+					)
 
 				if props.has("anti-aliasing"):
 					new_props[style_type] = "Flat"
@@ -143,3 +151,8 @@ func _shorthand_sides(
 
 	for i in range(0, sides.size()):
 		props[prefix + "-" + sides[i]] = side_values[i]
+
+
+func _vector2(props: Dictionary, value: String, prefix: String):
+	var split = value.split(" ")
+	props[prefix] = "Vector2(%s)" % ", ".join(split)

--- a/project.godot
+++ b/project.godot
@@ -11,8 +11,7 @@ config_version=5
 [application]
 
 config/name="Godot-CSS-Theme"
-run/main_scene="res://demo/Demo.tscn"
-config/features=PackedStringArray("4.1")
+config/features=PackedStringArray("4.3")
 config/icon="res://icon.png"
 
 [editor_plugins]


### PR DESCRIPTION
- Update project to Godot 4.3 stable.
- Update font color property names after a change on Godot's side.
- Add missing StyleBoxFlat related attributes to Simplified CSS.
- Update FEATURE documentation to match new Simplified CSS attributes.

Note: The GUT addon is currently out of date. I tried fetching the latest GUT from the asset store, but still had problems (console errors). I didn't update any of the tests as a result. Apologies if they are now broken.