### PR TITLE
Feature: Implemented import plugin

### DIFF
--- a/addons/godot-css-theme/import_plugin.gd
+++ b/addons/godot-css-theme/import_plugin.gd
@@ -1,0 +1,30 @@
+@tool
+class_name CSSImportPlugin
+extends EditorImportPlugin
+
+func _get_importer_name(): return "Godot CSS Importer"
+func _get_visible_name(): return "Godot CSS Importer"
+func _get_recognized_extensions(): return ["css"];
+func _get_save_extension(): return "tres";
+func _get_resource_type(): return "Theme";
+func _get_priority(): return 1;
+func _get_preset_count(): return 0;
+func _get_import_order(): return 2;
+func _can_import_threaded(): return true;
+func _get_import_options(str, int): return [];
+func _get_option_visibility(path: String, optionName: StringName, options: Dictionary): return true;
+
+func _import(css_path: String, save_path: String, _o, _p, _g):
+	var stylesheet = CSSParser.new().parse(css_path);
+
+	if not stylesheet:
+		return ERR_PARSE_ERROR;
+
+	var full_stylesheet = CSSSimplifier.new().simplify(stylesheet);
+	var themes = ThemeApplier.new().apply_css(full_stylesheet);
+
+	var main_theme = themes.get("", null);
+	if not main_theme:
+		return ERR_PARSE_ERROR;
+
+	return ResourceSaver.save(main_theme, save_path + ".tres");

--- a/addons/godot-css-theme/plugin.gd
+++ b/addons/godot-css-theme/plugin.gd
@@ -4,14 +4,19 @@ extends EditorPlugin
 const EDITOR = preload("res://addons/godot-css-theme/editor/css_editor.tscn")
 
 var file_editor
+var import_plugin
 
 func _enter_tree():
 	file_editor = EDITOR.instantiate()
 	get_editor_interface().get_editor_main_screen().add_child(file_editor)
 	_make_visible(false)
 
+	import_plugin = preload("res://addons/godot-css-theme/import_plugin.gd").new();
+	add_import_plugin(import_plugin)
+
 func _exit_tree():
 	get_editor_interface().get_editor_main_screen().remove_child(file_editor)
+	remove_import_plugin(import_plugin)
 
 func _has_main_screen():
 	return true


### PR DESCRIPTION
This is a small enhancement for this plugin that makes Godot identify CSS files as themes without manual conversion

Known issues:
- Classes are not supported and will be skipped during import